### PR TITLE
fix: supabase install 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "supabase:login": "npx supabase login",
     "gen": "supabase gen types typescript --project-id nfbfehavnhjtitiuesjo --schema public > src/types/supabase.ts"
   },
   "dependencies": {
@@ -20,7 +21,6 @@
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
-    "supabase": ">=1.8.1",
     "zustand": "^4.5.4"
   },
   "devDependencies": {
@@ -30,6 +30,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.4",
     "postcss": "^8",
+    "supabase": "^1.183.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4220,10 +4220,10 @@ sucrase@^3.32.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
-supabase@>=1.8.1:
-  version "1.178.2"
-  resolved "https://registry.yarnpkg.com/supabase/-/supabase-1.178.2.tgz#f7efaed43031258f9770f7a287cf26becd8f5083"
-  integrity sha512-JdjNY56cF5PbuhFdhgdYah5qXOPRsLQn0kXaY7uapTFopdIFX4tRiFXqKSig8S0SdznF/y/f6vLdq30Sek1ZZQ==
+supabase@^1.183.5:
+  version "1.183.5"
+  resolved "https://registry.yarnpkg.com/supabase/-/supabase-1.183.5.tgz#716c33ebfdf097a3a696a6e613c4d5eab60ac917"
+  integrity sha512-PYhxHHoSaEJSoDDQ+SN8iumfSmVQ8cHmBFB/GKhKZV2rDcVAPqe7HiEje37IuXCenOSamdvN8jQ8548tcsq4xw==
   dependencies:
     bin-links "^4.0.3"
     https-proxy-agent "^7.0.2"


### PR DESCRIPTION
- 알 수 없는 모종의 이유로 나는 잘되지만 다른 분들이 supabase를 찾을 수 없다는 에러를 만나서 디펜던시 및 버전을 수정하였습니다....
- 먼저 로그인이 되어있지 않으면 yarn gen인 supabase에서 타입 정의가 동작하지 않으므로, 일회성으로 먼저 토큰 발급을 받아주세요.


1. yarn 다시 하기
2. supabase 로그인하기

먼저 아래 코드를 실행하신 후 Enter를 눌러주세요!
```
npx supabase login
```
이후 크롬창이 열리면 다시 vscode로 돌아와서
```
yarn gen
```
을 실행시키면 정상적으로 동작 됩니다!